### PR TITLE
Fixed touch event issue with custom EditText padding

### DIFF
--- a/library/src/main/java/com/scottyab/showhidepasswordedittext/ShowHidePasswordEditText.java
+++ b/library/src/main/java/com/scottyab/showhidepasswordedittext/ShowHidePasswordEditText.java
@@ -133,7 +133,7 @@ public class ShowHidePasswordEditText extends AppCompatEditText {
 
     if (event.getAction() == MotionEvent.ACTION_UP && drawableEnd != null) {
       bounds = drawableEnd.getBounds();
-      final int x = (int) event.getX();
+      final int x = (int) event.getX() + getPaddingRight();
 
       //check if the touch is within bounds of drawableEnd icon
       if ((leftToRight && (x >= (this.getRight() - bounds.width()))) ||


### PR DESCRIPTION
If a EditText padding is set, the touch event won't respond to the exact drawableEnd icon position
